### PR TITLE
Added line break in the cropping and padding alignment section, and fixed a tiny typo

### DIFF
--- a/level-2.md
+++ b/level-2.md
@@ -54,10 +54,10 @@ Use `anchor` to control the alignment used by fit modes 'crop' and 'pad'.
 
 Valid values are `topleft|topcenter|topright|middleleft|middlecenter|middleright|bottomleft|bottomcenter|bottomright`.
 
-When used with `mode=crop`, the anchor specifies the area of the image to be preserved. 
+When used with `mode=crop`, the anchor specifies the area of the image to be preserved.  
 When used with `mode=pad`, the anchor specifies the area of the image that will not get whitespace. 
 
-## Backround Color
+## Background Color
 
 If a background color is specified, it MUST be used as the matte color regardless of the output format.
 


### PR DESCRIPTION
This makes it a bit easier to see that there are two different fit modes that affects the alignment.

Also fixed a tiny typo where "background" was misspelled as "backround".
